### PR TITLE
v2 API, o1 models metadata, and support typos in model names

### DIFF
--- a/src/functions/describe-model.ts
+++ b/src/functions/describe-model.ts
@@ -10,8 +10,11 @@ export class describeModel extends Tool {
       properties: {
         model: {
           type: "string",
-          description:
-            'The model to describe. Looks like "registry/model-name". For example, `azureml/Phi-3-medium-128k-instruct` or `azure-openai/gpt-4o',
+          description: [
+            'The model to describe. Looks like "model-name". For example, `Phi-3-medium-128k-instruct` or `gpt-4o`.',
+            'The list of models is available in the context window of the chat, in the `<-- LIST OF MODELS -->` section.',
+            'If the model name is not found in the list of models, pick the closest matching model from the list.',
+          ].join("\n"),
         },
       },
       required: ["model"],
@@ -30,12 +33,11 @@ export class describeModel extends Tool {
     const systemMessage = [
       "The user is asking about the AI model with the following details:",
       `\tModel Name: ${model.name}`,
-      `\tModel Version: ${model.model_version}`,
+      `\tModel Version: ${model.version}`,
       `\tPublisher: ${model.publisher}`,
-      `\tModel Family: ${model.model_family}`,
-      `\tModel Registry: ${model.model_registry}`,
+      `\tModel Registry: ${model.registryName}`,
       `\tLicense: ${model.license}`,
-      `\tTask: ${model.task}`,
+      `\tTask: ${model.inferenceTasks.join(", ")}`,
       `\tDescription: ${model.description}`,
       `\tSummary: ${model.summary}`,
       "\n",

--- a/src/functions/execute-model.ts
+++ b/src/functions/execute-model.ts
@@ -30,6 +30,7 @@ Example Queries (IMPORTANT: Phrasing doesn't have to match):
             "The name of the model to execute. It is ONLY the name of the model, not the publisher or registry.",
             "For example: `gpt-4o`, or `cohere-command-r-plus`.",
             "The list of models is available in the context window of the chat, in the `<-- LIST OF MODELS -->` section.",
+            "If the model name is not found in the list of models, pick the closest matching model from the list.",
           ].join("\n"),
         },
         instruction: {

--- a/src/functions/list-models.ts
+++ b/src/functions/list-models.ts
@@ -27,7 +27,7 @@ export class listModels extends Tool {
       "That list of models is as follows:",
       JSON.stringify(
         models.map((model) => ({
-          name: model.friendly_name,
+          name: model.displayName,
           publisher: model.publisher,
           description: model.summary,
         }))

--- a/src/models-api.ts
+++ b/src/models-api.ts
@@ -2,16 +2,14 @@ import OpenAI from "openai";
 
 // Model is the structure of a model in the model catalog.
 export interface Model {
-  id: string;
   name: string;
-  friendly_name: string;
-  model_version: number;
+  displayName: string;
+  version: number;
   publisher: string;
-  model_family: string;
-  model_registry: string;
+  registryName: string;
   license: string;
-  task: string;
-  description: string;
+  inferenceTasks: string[];
+  description?: string;
   summary: string;
 }
 
@@ -44,19 +42,23 @@ export class ModelsAPI {
   }
 
   async getModel(modelName: string): Promise<Model> {
+    const modelFromIndex = await this.getModelFromIndex(modelName);
+
     const modelRes = await fetch(
-      "https://modelcatalog.azure-api.net/v1/model/" + modelName
+      `https://eastus.api.azureml.ms/asset-gallery/v1.0/${modelFromIndex.registryName}/models/${modelFromIndex.name}/version/${modelFromIndex.version}`,
     );
     if (!modelRes.ok) {
-      throw new Error(`Failed to fetch ${modelName} from the model catalog.`);
+      throw new Error(`Failed to fetch ${modelName} details from the model catalog.`);
     }
     const model = (await modelRes.json()) as Model;
     return model;
   }
 
   async getModelSchema(modelName: string): Promise<ModelSchema> {
+    const modelFromIndex = await this.getModelFromIndex(modelName);
+
     const modelSchemaRes = await fetch(
-      `https://modelcatalogcachev2-ebendjczf0c5dzca.b02.azurefd.net/widgets/en/Serverless/${modelName.toLowerCase()}.json`
+      `https://modelcatalogcachev2-ebendjczf0c5dzca.b02.azurefd.net/widgets/en/Serverless/${modelFromIndex.registryName.toLowerCase()}/${modelFromIndex.name.toLowerCase()}.json`
     );
     if (!modelSchemaRes.ok) {
       throw new Error(
@@ -73,14 +75,36 @@ export class ModelsAPI {
     }
 
     const modelsRes = await fetch(
-      "https://modelcatalog.azure-api.net/v1/models"
+      "https://eastus.api.azureml.ms/asset-gallery/v1.0/models",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          filters: [
+            { field: "freePlayground", values: ["true"], operator: "eq" },
+            { field: "labels", values: ["latest"], operator: "eq" },
+          ],
+          order: [{ field: "displayName", direction: "Asc" }],
+        }),
+      }
     );
     if (!modelsRes.ok) {
       throw new Error("Failed to fetch models from the model catalog");
     }
 
-    const models = (await modelsRes.json()) as Model[];
+    const models = (await modelsRes.json()).summaries as Model[];
     this._models = models;
     return models;
+  }
+
+  async getModelFromIndex(modelName: string): Promise<Model> {
+    this._models = this._models || (await this.listModels());
+    const modelFromIndex = this._models.find((model) => model.name === modelName);
+    if (!modelFromIndex) {
+      throw new Error(`Failed to fetch ${modelName} from the model catalog.`);
+    }
+    return modelFromIndex;
   }
 }

--- a/src/models-api.ts
+++ b/src/models-api.ts
@@ -4,7 +4,7 @@ import OpenAI from "openai";
 export interface Model {
   name: string;
   displayName: string;
-  version: number;
+  version: string;
   publisher: string;
   registryName: string;
   license: string;


### PR DESCRIPTION
- Use the updated models metadata API, which changes the shape of the models object
  - As a result of this, we've got to collect some extra data from the index endpoint response before fetching schema/details. No big deal, since it's already in-memory
- Include the basic metadata about o1 models in the list
- Make more resilient to typoed or missing model names by telling the model to just pick the closest one (e.g. so "Phi 3 mini" becomes "Phi-3-mini-128k-instruct")
- Fixes an issue where we were passing params that were unsupported for some models, so `executeModel` was failing for models like Mistral-Nemo