### PR TITLE
Send error data when error occurs to display user error message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -225,6 +225,7 @@ const server = createServer(async (request, response) => {
   } catch (err) {
     console.error(err);
     response.statusCode = 500
+    response.write("data: Something went wrong\n\n")
     response.end()
   }
 });


### PR DESCRIPTION
## Description
- An empty 500 without response text doesn't seem to be handled correctly by copilot chat
- Sending back error text triggers the error state and shows the warning error banner ⚠️ 

## After
<img width="621" alt="Screenshot 2024-10-10 at 4 13 56 PM" src="https://github.com/user-attachments/assets/6bcdac45-c60f-4cad-b90d-4637948003cd">

## Before

<img width="615" alt="Screenshot 2024-10-10 at 4 36 26 PM" src="https://github.com/user-attachments/assets/080d5c60-ee1d-45ab-9622-26e17e9ed017">
