### PR TITLE
Remove waitlist copy from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is an agent-based [GitHub Copilot Extension](https://docs.github.com/en/copilot/using-github-copilot/using-extensions-to-integrate-external-tools-with-copilot-chat) that provides a way to interact with [GitHub Models](https://github.blog/news-insights/product-news/introducing-github-models/), directly in Copilot Chat.
 
 >[!NOTE]
-> Copilot Extensions are in public preview and GitHub Models are in limited public preview. They may be subject to change. To request access to GitHub Models, [join the waitlist](https://github.com/marketplace/models/waitlist).
+> Copilot Extensions are in public preview and GitHub Models are in limited public preview. They may be subject to change.
 
 ## What it can do
 


### PR DESCRIPTION
Now that the waitlist has been fully rolled out, let's remove that sentence from the README.