### PR TITLE
Bump copilot-extensions/preview-sdk to 5.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@copilot-extensions/preview-sdk": "^4.0.2",
+        "@copilot-extensions/preview-sdk": "^5.0.1",
         "express": "^4.19.2",
         "openai": "^4.55.0"
       },
@@ -21,9 +21,10 @@
       }
     },
     "node_modules/@copilot-extensions/preview-sdk": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@copilot-extensions/preview-sdk/-/preview-sdk-4.0.2.tgz",
-      "integrity": "sha512-t0FheQZNgc7Z9aCcH1B+PbrlLcof98/yvME1sXrc97N5YA7RZ74H+7HoayJ8XMzg7cRcfwoVmXrOagAL0GZL2g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@copilot-extensions/preview-sdk/-/preview-sdk-5.0.1.tgz",
+      "integrity": "sha512-DvuJtTBl0aWvZnaNYVBiXuCdJN27ya6GYcJjv6J42Pnu1ubXHm8GHzUhIgLU/35c87HVHaITVah/jXogH3eChg==",
+      "license": "MIT",
       "dependencies": {
         "@octokit/request": "^9.1.3",
         "@octokit/request-error": "^6.1.4"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@copilot-extensions/preview-sdk": "^4.0.2",
+    "@copilot-extensions/preview-sdk": "^5.0.1",
     "express": "^4.19.2",
     "openai": "^4.55.0"
   },


### PR DESCRIPTION
Do a version bump to the current latest release, https://github.com/copilot-extensions/preview-sdk.js/releases/tag/v5.0.1.